### PR TITLE
Update get_task_status.js to reload page if the task has been completed

### DIFF
--- a/taskstate/static/taskstate/get_task_status.js
+++ b/taskstate/static/taskstate/get_task_status.js
@@ -120,6 +120,9 @@
                 // completing. The server will automatically set all tasks to
                 // the correct seen status.
                 send_payload(task_seen_socket);
+                if (status == 'done'){
+                    location.reload()
+                }
             }
             task_status.textContent = status;
             task_element.dataset.status = status;


### PR DESCRIPTION
This should probably be option that is passed down but seeing as I am working on a project that has this package implemented and it is no longer maintained. I hope this will be accpected.